### PR TITLE
Use .json for JMH-results and rework benchmark_evaluation.py

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           java-version: 11
       - name: Install black
-        run: pip install --force-reinstall black==22.8.0
+        run: pip install --force-reinstall `grep black requirements.txt`
       - name: Cache SonarCloud packages
         uses: actions/cache@v1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /.classpath
 /.project
 /.settings/
+/.venv/

--- a/README.md
+++ b/README.md
@@ -129,3 +129,11 @@ $\sqrt{\frac{\frac{8317}{3528}\ln(2)-1}{m}}\approx \frac{0.796}{\sqrt{m}}$. This
 | 7              | <img src="test-results/estimation-error-p7.png" width="250">  | 14       | <img src="test-results/estimation-error-p14.png" width="250">  |
 | 8              | <img src="test-results/estimation-error-p8.png" width="250">  | 15       | <img src="test-results/estimation-error-p15.png" width="250">  |
 | 9              | <img src="test-results/estimation-error-p9.png" width="250">  | 16       | <img src="test-results/estimation-error-p16.png" width="250">  |
+
+## Contribution FAQ
+
+### Python
+
+This project contains python code. We recommend using a python virtual environment in a `.venv` directory. If your are new, please follow the steps outlined
+in the [official Python documentation](https://docs.python.org/3/tutorial/venv.html#creating-virtual-environments) for creation and activation.
+To install the required dependencies including black, please execute `pip install -r requirements.txt`.

--- a/build.gradle
+++ b/build.gradle
@@ -134,18 +134,19 @@ jmh {
     warmupBatchSize = 1
     warmup = '1s'
     iterations = 20
+    resultFormat = "JSON"
 }
 
 task evaluateBenchmarks(type:Exec) {
     group "evaluation"
     workingDir '.'
-    commandLine 'python3', 'python/benchmark_evaluation.py'
+    commandLine 'python', 'python/benchmark_evaluation.py'
 }
 
 task evaluateEstimationErrors(type:Exec) {
     group "evaluation"
     workingDir '.'
-    commandLine 'python3', 'python/estimation_error_evaluation.py'
+    commandLine 'python', 'python/estimation_error_evaluation.py'
 }
 
 task simulateEstimationErrors(type: JavaExec) {
@@ -167,9 +168,11 @@ tasks.register('checkStatusForBenchmarks') {
 tasks.register('copyBenchmarkReport', Copy) {
     def proc = "git rev-parse HEAD".execute()
     def revision = proc.text.trim()
-    rename ('results.txt', new Date().format('yyyy-MM-dd-HH-mm-ss') + ' ' + revision + '.txt')
-    from file('build/results/jmh/results.txt')
-    into file('benchmark-results/')
+    from('build/results/jmh/') {
+        include 'results.*'
+        rename 'results', new Date().format('yyyy-MM-dd-HH-mm-ss') + ' ' + revision
+    }
+    into 'benchmark-results'
 }
 
 tasks.register('deleteBenchmarkReport', Delete) {

--- a/python/benchmark_evaluation.py
+++ b/python/benchmark_evaluation.py
@@ -28,92 +28,16 @@ matplotlib.use("PDF")
 import matplotlib.pyplot as plt
 
 
-Record = namedtuple(
-    "Record",
-    [
-        "commit_date",
-        "exec_date",
-        "revision",
-        "algorithm",
-        "test",
-        "avg",
-        "std",
-        "parameters",
-    ],
-)
-DateCommit = namedtuple("DateCommit", ["commit_date", "revision", "exec_date"])
-
-
-def parse_exec_date_from_benchmark_result_file(file_name):
-    s = list(file_name.split()[0])
-    s[-3] = ":"
-    s[-6] = ":"
-    s[-9] = " "
-    return "".join(s)
-
-
-def parse_revision_from_benchmark_result_file(file_name):
-    return file_name.split(" ")[1].split(".")[0]
-
-
 def get_commit_date(commit, git_repo):
     return time.strftime(
         "%Y-%m-%d %H:%M:%S", time.localtime(git_repo.commit(commit).committed_date)
     )
 
 
-def read_data_file(benchmark_result_path, benchmark_result_file, git_repo):
-    data = []
-    exec_date = parse_exec_date_from_benchmark_result_file(benchmark_result_file)
-    revision = parse_revision_from_benchmark_result_file(benchmark_result_file)
-    commit_date = get_commit_date(revision, git_repo)
-
-    # print(f"Reading file {benchmark_result_path / benchmark_result_file} as .txt")
-
-    with open(benchmark_result_path / benchmark_result_file) as file:
-        lines = file.readlines()
-        split_header = lines[0].split()
-        parameter_names = []
-        for w in split_header:
-            if w[0] == "(" and w[-1] == ")":
-                parameter_names.append(w[1:-1])
-
-        num_parameters = len(parameter_names)
-        for line in lines[1:]:
-            split_line = line.split()
-            algorithm = split_line[0].split(".")[-2]
-            test = split_line[0].split(".")[-1]
-            avg = float(split_line[3 + num_parameters])
-            std = float(split_line[5 + num_parameters])
-            parameters = {}
-            for h in range(0, num_parameters):
-                p = split_line[1 + h]
-                if p != "N/A":
-                    parameters[parameter_names[h]] = split_line[1 + h]
-
-            data.append(
-                Record(
-                    commit_date=commit_date,
-                    exec_date=exec_date,
-                    revision=revision,
-                    algorithm=algorithm,
-                    test=test,
-                    avg=avg,
-                    std=std,
-                    parameters=parameters,
-                )
-            )
-    return data
-
-
 def read_data_files_json_df(benchmark_result_path, benchmark_result_files, git_repo):
-    def read_json(f):
-        # print(f"Reading file {f} as json")
-        return pd.read_json(f, orient="record")
-
     # read all files
     files = [join(benchmark_result_path, f) for f in benchmark_result_files]
-    df = pd.concat({f: read_json(f) for f in files})
+    df = pd.concat({f: pd.read_json(f, orient="record") for f in files})
 
     # add columns "filename" and "indexInFile"
     df.index.names = ["filename", "indexInFile"]
@@ -136,39 +60,26 @@ def read_data_files_json_df(benchmark_result_path, benchmark_result_files, git_r
         df["params"] = None
     df["params"] = [{} if x is None else x for x in df["params"]]
 
-    # add the avg and std columns, note that this only makes sense if score actually represents an average
-    df["avg"] = df["primaryMetric"].apply(lambda pm: pm["score"])
-    df["std"] = df["primaryMetric"].apply(lambda pm: pm["scoreError"])
+    # make the params column hashable (necessary for groupby,...)
+    df["params"] = df["params"].apply(lambda mydict: frozenset(mydict.items()))
+
+    # make the values of primaryMetric easily accessible as individual columns
+    df = pd.concat(
+        [df, df["primaryMetric"].apply(pd.Series).add_prefix("primaryMetric.")], axis=1
+    )
+    df["primaryMetric.scoreConfidence.lower"] = df[
+        "primaryMetric.scoreConfidence"
+    ].apply(lambda x: x[0])
+    df["primaryMetric.scoreConfidence.upper"] = df[
+        "primaryMetric.scoreConfidence"
+    ].apply(lambda x: x[1])
     return df
 
 
-def read_data_files_json(benchmark_result_path, benchmark_result_files, git_repo):
-    df_json = read_data_files_json_df(
-        benchmark_result_path, benchmark_result_files, git_repo
-    )
-    data_json = [
-        Record(*row[1:])  # list comprehension, make new records...
-        for row in df_json.rename(columns={"params": "parameters"})[
-            [  # select the columns in the correct order for the "Record" NamedTuple
-                "commit_date",
-                "exec_date",
-                "revision",
-                "algorithm",
-                "test",
-                "avg",
-                "std",
-                "parameters",
-            ]
-        ].itertuples()
-    ]
-    return data_json
-
-
-def read_data(bechmark_result_directory, git_repo_path="."):
+def read_data(benchmark_result_path, git_repo_path="."):
     git_repo = git.Repo(git_repo_path)
-    benchmark_result_path = Path(bechmark_result_directory)
 
-    benchmark_result_files_json = [
+    benchmark_result_files = [
         f
         for f in listdir(benchmark_result_path)
         if isfile(join(benchmark_result_path, f))
@@ -176,148 +87,73 @@ def read_data(bechmark_result_directory, git_repo_path="."):
         and f.endswith(".json")
     ]
 
-    # skip txt files if a json-file with the same base filename was alreasy read
-    benchmark_result_files_txt_exclude = [
-        f.rsplit(".", 1)[0] for f in benchmark_result_files_json
-    ]
-    benchmark_result_files_txt = [
-        f
-        for f in listdir(benchmark_result_path)
-        if isfile(join(benchmark_result_path, f))
-        and getsize(join(benchmark_result_path, f)) > 0
-        and f.endswith(".txt")
-        and f.rsplit(".", 1)[0] not in benchmark_result_files_txt_exclude
-    ]
-
-    data = []
-
-    # add json data
-    data = data + read_data_files_json(
-        benchmark_result_path, benchmark_result_files_json, git_repo
-    )
-
-    # add txt data
-    for benchmark_result_file in benchmark_result_files_txt:
-        data = data + read_data_file(
-            benchmark_result_path, benchmark_result_file, git_repo
-        )
-
-    return data
-
-
-def splitted_data_by_test_and_parameters(data):
-    result = defaultdict(list)
-    for d in data:
-        test_name = d.test
-        if len(d.parameters) > 0:
-            test_name += " ("
-            for param in sorted(d.parameters):
-                test_name += param + "=" + d.parameters[param] + ";"
-            test_name = test_name[:-1]
-            test_name += ")"
-        result[test_name].append(d)
-    return result
-
-
-def split_data_by_algorithm(data):
-    result = defaultdict(list)
-    for d in data:
-        result[d.algorithm].append(d)
-    return result
-
-
-def format_label(label_data):
-    return (
-        "e:"
-        + label_data.exec_date
-        + " c: "
-        + label_data.commit_date
-        + "\n"
-        + label_data.revision
+    return read_data_files_json_df(
+        benchmark_result_path, benchmark_result_files, git_repo
     )
 
 
-def plot_algorithm(ax, labels, algorithm, data):
-    values = {
-        DateCommit(
-            commit_date=d.commit_date, revision=d.revision, exec_date=d.exec_date
-        ): d
-        for d in data
+def get_plot_linestyles(algorithm):
+    styles = {}
+    algorithms_ordered = [
+        "FarmHash",
+        "Komihash",
+        "Murmur3_128",
+        "Murmur3_32",
+        "XXH3",
+        "Wyhash",
+        "UnorderedHashTest",
+    ]
+    for i, alg in enumerate(algorithms_ordered):
+        if alg in algorithm:
+            styles["color"] = f"C{i+1}"
+
+    linestyle_map = {
+        "ZeroAllocationHashing": "dotted",
+        "Guava": "dashed",
+        "GreenrobotEssentials": (0, (3, 1, 1, 1, 1, 1)),
     }
+    for alg, linestyle in linestyle_map.items():
+        if alg in algorithm:
+            styles["linestyle"] = linestyle
+    return styles
 
-    label_strings = []
-    y_values = []
 
-    for l in labels:
-        if l in values:
-            label_strings.append(format_label(l))
-            y_values.append(values[l].avg)
+def make_chart(df, output_path, name, scoreUnit, mode):
+    df["revision"] = "\n" + df["revision"]  # add a line break to the xlabels
 
-    if "FarmHash" in algorithm:
-        color = "blue"
-    elif "Komihash" in algorithm:
-        color = "green"
-    elif "Murmur3_128" in algorithm:
-        color = "black"
-    elif "Murmur3_32" in algorithm:
-        color = "red"
-    elif "XXH3" in algorithm:
-        color = "brown"
-    elif "Wyhash" in algorithm:
-        color = "magenta"
-    elif "UnorderedHashTest" in algorithm:
-        color = "black"
-    else:
-        color = None
-
-    linestyle = "solid"
-    if "ZeroAllocationHashing" in algorithm:
-        linestyle = "dotted"
-    elif "Guava" in algorithm:
-        linestyle = "dashed"
-    elif "GreenrobotEssentials" in algorithm:
-        linestyle = (0, (3, 1, 1, 1, 1, 1))
-
-    ax.plot(
-        label_strings,
-        y_values,
-        label=algorithm,
-        color=color,
-        linestyle=linestyle,
-        marker="o",
+    df_plot = df.pivot(
+        columns=["algorithm"],
+        index=["exec_date", "commit_date", "revision"],  # x axis for plotting
     )
-
-
-def make_chart(test, data, output_path):
-    labels = sorted(
-        set(
-            DateCommit(
-                commit_date=d.commit_date, revision=d.revision, exec_date=d.exec_date
-            )
-            for d in data
-        )
-    )
-    label_strings = [format_label(l) for l in labels]
-
-    splitted_data_by_algorithm = split_data_by_algorithm(data)
 
     fig, ax = plt.subplots(1, 1)
     fig.set_size_inches(24, 18)
 
-    ax.plot(label_strings, [None for _ in label_strings], alpha=0.0)
-
-    for algorithm in splitted_data_by_algorithm:
-        plot_algorithm(ax, labels, algorithm, splitted_data_by_algorithm[algorithm])
+    for algorithm in df_plot["primaryMetric.score"].columns:
+        df_plot["primaryMetric.score"][algorithm].plot(
+            ax=ax,
+            marker="o",
+            ylabel=f"score ({mode}) in {scoreUnit}",
+            yerr=[
+                df_plot["primaryMetric.score"][algorithm]
+                - df_plot["primaryMetric.scoreConfidence.lower"][algorithm],
+                df_plot["primaryMetric.scoreConfidence.upper"][algorithm]
+                - df_plot["primaryMetric.score"][algorithm],
+            ],
+            elinewidth=0.5,
+            capsize=4,
+            **get_plot_linestyles(algorithm),
+        )
 
     ax.legend(loc="lower center", bbox_to_anchor=(0.5, -0.37), ncol=4, handlelength=8)
 
     fig.subplots_adjust(top=0.95, bottom=0.27, left=0.05, right=0.95)
 
-    ax.set_title(test)
+    ax.set_title(name)
     ax.set_ylim([0, ax.get_ylim()[1]])
     ax.xaxis.set_tick_params(rotation=90)
     fig.savefig(
-        output_path / (test + ".pdf"),
+        output_path / (name + ".pdf"),
         format="pdf",
         dpi=1600,
         metadata={"creationDate": None},
@@ -326,13 +162,20 @@ def make_chart(test, data, output_path):
 
 
 def main():
-    data = read_data("benchmark-results")
-    splitted_data_by_test_and_parameters_ = splitted_data_by_test_and_parameters(data)
+    # load all .json benchmark result files to a single pandas.DataFrame
+    df = read_data(Path("./benchmark-results/"))
 
-    for test in splitted_data_by_test_and_parameters_:
-        make_chart(
-            test, splitted_data_by_test_and_parameters_[test], Path("benchmark-results")
+    # group by test and params (and more, but we expect this to be unique, otherwise the output file would be overwritten)
+    # create and save plot for each group
+    for (test, params, scoreUnit, mode), data in df.groupby(
+        ["test", "params", "primaryMetric.scoreUnit", "mode"]
+    ):
+        name = test + (
+            " (" + ";".join([f"{i[0]}={i[1]}" for i in params]) + ")"
+            if len(params) > 0
+            else ""
         )
+        make_chart(data, Path("./benchmark-results/"), name, scoreUnit, mode)
 
 
 if __name__ == "__main__":

--- a/python/benchmark_evaluation.py
+++ b/python/benchmark_evaluation.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-
 import time
 from collections import defaultdict, namedtuple
 from os import listdir

--- a/python/benchmark_evaluation.py
+++ b/python/benchmark_evaluation.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import math
 import time
 from collections import defaultdict, namedtuple
 from os import listdir
@@ -63,7 +64,10 @@ def read_data_files_json_df(benchmark_result_path, benchmark_result_files, git_r
     # add params column if missing
     if "params" not in df:
         df["params"] = None
-    df["params"] = [{} if x is None else x for x in df["params"]]
+    df["params"] = [
+        {} if x is None or (isinstance(x, float) and math.isnan(x)) else x
+        for x in df["params"]
+    ]
 
     # make the params column hashable (necessary for groupby,...)
     df["params"] = df["params"].apply(lambda mydict: frozenset(mydict.items()))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+black==22.6.0
+matplotlib
+gitpython
+pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 black==22.8.0
-matplotlib
+click
 gitpython
+matplotlib
 pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-black==22.6.0
+black==22.8.0
 matplotlib
 gitpython
 pandas


### PR DESCRIPTION
This PR will set the JMH output format to JSON, which makes it easier to parse the output files and allows the usage of other tools such as [gradle-jmh-report](https://github.com/jzillmann/gradle-jmh-report).

Support for JSON is added `benchmark_evaluation.py`, which has been completely reworked and also supports some command line arguments, e.g. for adding the confidence interval to the plots and disabling the git integration.

Notes:
- If Gradle is run from an IDE like IntelliJ, the python virtual environment might not be used. Either run Gradle from within the venv using the command line or install the dependencies from `requirements.txt` globally.