### PR TITLE
Add copy method to HashStream

### DIFF
--- a/src/main/java/com/dynatrace/hash4j/hashing/AbstractKomihash.java
+++ b/src/main/java/com/dynatrace/hash4j/hashing/AbstractKomihash.java
@@ -343,6 +343,19 @@ abstract class AbstractKomihash extends AbstractHasher64 {
 
       return finalizeGetAsLong(se1, se5, off, len);
     }
+
+    protected void copyTo(HashStreamImpl hashStream) {
+      hashStream.see1 = see1;
+      hashStream.see2 = see2;
+      hashStream.see3 = see3;
+      hashStream.see4 = see4;
+      hashStream.see5 = see5;
+      hashStream.see6 = see6;
+      hashStream.see7 = see7;
+      hashStream.see8 = see8;
+      hashStream.byteCount = byteCount;
+      System.arraycopy(buffer, 0, hashStream.buffer, 0, buffer.length);
+    }
   }
 
   protected static long finish(long r2h, long r2l, long see5) {

--- a/src/main/java/com/dynatrace/hash4j/hashing/AbstractWyhashFinal.java
+++ b/src/main/java/com/dynatrace/hash4j/hashing/AbstractWyhashFinal.java
@@ -270,6 +270,18 @@ abstract class AbstractWyhashFinal extends AbstractHasher64 {
     }
 
     @Override
+    public HashStream64 copy() {
+      final HashStreamImpl hashStream = new HashStreamImpl();
+      hashStream.byteCount = byteCount;
+      hashStream.offset = offset;
+      hashStream.see0 = see0;
+      hashStream.see1 = see1;
+      hashStream.see2 = see2;
+      System.arraycopy(buffer, 0, hashStream.buffer, 0, buffer.length);
+      return hashStream;
+    }
+
+    @Override
     public HashStream64 putByte(byte v) {
       buffer[offset] = v;
       offset += 1;

--- a/src/main/java/com/dynatrace/hash4j/hashing/FarmHashNa.java
+++ b/src/main/java/com/dynatrace/hash4j/hashing/FarmHashNa.java
@@ -278,6 +278,22 @@ class FarmHashNa extends AbstractFarmHash {
     }
 
     @Override
+    public HashStream64 copy() {
+      final HashStreamImpl hashStream = new HashStreamImpl();
+      hashStream.x = x;
+      hashStream.y = y;
+      hashStream.z = z;
+      hashStream.v0 = v0;
+      hashStream.v1 = v1;
+      hashStream.w0 = w0;
+      hashStream.w1 = w1;
+      hashStream.bufferCount = bufferCount;
+      hashStream.init = init;
+      System.arraycopy(buffer, 0, hashStream.buffer, 0, buffer.length);
+      return hashStream;
+    }
+
+    @Override
     protected void processBuffer(
         long b0, long b1, long b2, long b3, long b4, long b5, long b6, long b7) {
       if (init) x += b0;

--- a/src/main/java/com/dynatrace/hash4j/hashing/FarmHashUo.java
+++ b/src/main/java/com/dynatrace/hash4j/hashing/FarmHashUo.java
@@ -358,6 +358,23 @@ class FarmHashUo extends AbstractFarmHash {
     }
 
     @Override
+    public HashStream64 copy() {
+      final HashStreamImpl hashStream = new HashStreamImpl();
+      hashStream.x = x;
+      hashStream.y = y;
+      hashStream.z = z;
+      hashStream.v0 = v0;
+      hashStream.v1 = v1;
+      hashStream.w0 = w0;
+      hashStream.w1 = w1;
+      hashStream.u = u;
+      hashStream.bufferCount = bufferCount;
+      hashStream.init = init;
+      System.arraycopy(buffer, 0, hashStream.buffer, 0, buffer.length);
+      return hashStream;
+    }
+
+    @Override
     protected void processBuffer(
         long b0, long b1, long b2, long b3, long b4, long b5, long b6, long b7) {
 

--- a/src/main/java/com/dynatrace/hash4j/hashing/HashStream.java
+++ b/src/main/java/com/dynatrace/hash4j/hashing/HashStream.java
@@ -169,4 +169,13 @@ interface HashStream extends HashSink {
    * @return this
    */
   HashStream reset();
+
+  /**
+   * Copies hash stream.
+   *
+   * <p>This allows to save the current state for reuse, without new hash computations.
+   *
+   * @return new instance
+   */
+  HashStream copy();
 }

--- a/src/main/java/com/dynatrace/hash4j/hashing/HashStream.java
+++ b/src/main/java/com/dynatrace/hash4j/hashing/HashStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Dynatrace LLC
+ * Copyright 2022-2024 Dynatrace LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/dynatrace/hash4j/hashing/HashStream128.java
+++ b/src/main/java/com/dynatrace/hash4j/hashing/HashStream128.java
@@ -173,4 +173,7 @@ public interface HashStream128 extends HashStream64 {
    */
   @Override
   HashStream128 reset();
+
+  @Override
+  HashStream128 copy();
 }

--- a/src/main/java/com/dynatrace/hash4j/hashing/HashStream32.java
+++ b/src/main/java/com/dynatrace/hash4j/hashing/HashStream32.java
@@ -161,4 +161,7 @@ public interface HashStream32 extends HashStream {
 
   @Override
   HashStream32 reset();
+
+  @Override
+  HashStream32 copy();
 }

--- a/src/main/java/com/dynatrace/hash4j/hashing/HashStream32.java
+++ b/src/main/java/com/dynatrace/hash4j/hashing/HashStream32.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Dynatrace LLC
+ * Copyright 2022-2024 Dynatrace LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/dynatrace/hash4j/hashing/HashStream64.java
+++ b/src/main/java/com/dynatrace/hash4j/hashing/HashStream64.java
@@ -173,4 +173,7 @@ public interface HashStream64 extends HashStream32 {
    */
   @Override
   HashStream64 reset();
+
+  @Override
+  HashStream64 copy();
 }

--- a/src/main/java/com/dynatrace/hash4j/hashing/Komihash4_3.java
+++ b/src/main/java/com/dynatrace/hash4j/hashing/Komihash4_3.java
@@ -333,6 +333,13 @@ class Komihash4_3 extends AbstractKomihash {
 
       return finish(r2h, r2l, se5);
     }
+
+    @Override
+    public HashStream64 copy() {
+      final HashStreamImpl hashStream = new HashStreamImpl();
+      copyTo(hashStream);
+      return hashStream;
+    }
   }
 
   @Override

--- a/src/main/java/com/dynatrace/hash4j/hashing/Komihash5_0.java
+++ b/src/main/java/com/dynatrace/hash4j/hashing/Komihash5_0.java
@@ -320,6 +320,13 @@ class Komihash5_0 extends AbstractKomihash {
 
       return finish(r2h, r2l, se5);
     }
+
+    @Override
+    public HashStream64 copy() {
+      final HashStreamImpl hashStream = new HashStreamImpl();
+      copyTo(hashStream);
+      return hashStream;
+    }
   }
 
   @Override

--- a/src/main/java/com/dynatrace/hash4j/hashing/Murmur3_128.java
+++ b/src/main/java/com/dynatrace/hash4j/hashing/Murmur3_128.java
@@ -242,6 +242,17 @@ class Murmur3_128 extends AbstractHasher128 {
     }
 
     @Override
+    public HashStream128 copy() {
+      final HashStreamImpl hashStream = new HashStreamImpl();
+      hashStream.h1 = h1;
+      hashStream.h2 = h2;
+      hashStream.buffer0 = buffer0;
+      hashStream.buffer1 = buffer1;
+      hashStream.bitCount = bitCount;
+      return hashStream;
+    }
+
+    @Override
     public HashStream128 putByte(byte b) {
       buffer1 |= ((b & 0xFFL) << bitCount);
       if ((bitCount & 0x38L) == 0x38L) {

--- a/src/main/java/com/dynatrace/hash4j/hashing/Murmur3_32.java
+++ b/src/main/java/com/dynatrace/hash4j/hashing/Murmur3_32.java
@@ -135,6 +135,16 @@ class Murmur3_32 extends AbstractHasher32 {
     }
 
     @Override
+    public HashStream32 copy() {
+      final HashStreamImpl hashStream = new HashStreamImpl();
+      hashStream.h1 = h1;
+      hashStream.buffer = buffer;
+      hashStream.shift = shift;
+      hashStream.length = length;
+      return hashStream;
+    }
+
+    @Override
     public HashStream32 putByte(byte b) {
       buffer |= ((b & 0xFFL) << shift);
       shift += 8;

--- a/src/main/java/com/dynatrace/hash4j/hashing/PolymurHash2_0.java
+++ b/src/main/java/com/dynatrace/hash4j/hashing/PolymurHash2_0.java
@@ -528,6 +528,16 @@ class PolymurHash2_0 extends AbstractHasher64 {
     }
 
     @Override
+    public HashStream64 copy() {
+      final HashStreamImpl hashStream = new HashStreamImpl();
+      hashStream.byteCount = byteCount;
+      hashStream.offset = offset;
+      hashStream.h = h;
+      System.arraycopy(buffer, 0, hashStream.buffer, 0, buffer.length);
+      return hashStream;
+    }
+
+    @Override
     public HashStream64 putByte(byte v) {
       buffer[offset] = v;
       offset += 1;

--- a/src/test/java/com/dynatrace/hash4j/hashing/AbstractHashStreamCompatibilityTest.java
+++ b/src/test/java/com/dynatrace/hash4j/hashing/AbstractHashStreamCompatibilityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Dynatrace LLC
+ * Copyright 2022-2024 Dynatrace LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ class AbstractHashStreamCompatibilityTest {
             throw new UnsupportedOperationException();
           }
 
-            @Override
+          @Override
           public int getHashBitSize() {
             return 128;
           }

--- a/src/test/java/com/dynatrace/hash4j/hashing/AbstractHashStreamCompatibilityTest.java
+++ b/src/test/java/com/dynatrace/hash4j/hashing/AbstractHashStreamCompatibilityTest.java
@@ -39,6 +39,11 @@ class AbstractHashStreamCompatibilityTest {
           }
 
           @Override
+          public HashStream128 copy() {
+            throw new UnsupportedOperationException();
+          }
+
+            @Override
           public int getHashBitSize() {
             return 128;
           }

--- a/src/test/java/com/dynatrace/hash4j/hashing/AbstractHasher128Test.java
+++ b/src/test/java/com/dynatrace/hash4j/hashing/AbstractHasher128Test.java
@@ -68,6 +68,11 @@ abstract class AbstractHasher128Test extends AbstractHasherTest {
         hashStream128.reset();
         return this;
       }
+
+      @Override
+      public HashStream128 copy() {
+        return hashStream128.copy();
+      }
     };
   }
 
@@ -120,6 +125,11 @@ abstract class AbstractHasher128Test extends AbstractHasherTest {
               @Override
               public HashStream128 reset() {
                 return this;
+              }
+
+              @Override
+              public HashStream128 copy() {
+                throw new UnsupportedOperationException();
               }
 
               @Override

--- a/src/test/java/com/dynatrace/hash4j/hashing/AbstractHasher128Test.java
+++ b/src/test/java/com/dynatrace/hash4j/hashing/AbstractHasher128Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Dynatrace LLC
+ * Copyright 2022-2024 Dynatrace LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/dynatrace/hash4j/hashing/AbstractHasher32Test.java
+++ b/src/test/java/com/dynatrace/hash4j/hashing/AbstractHasher32Test.java
@@ -61,6 +61,11 @@ abstract class AbstractHasher32Test extends AbstractHasherTest {
         hashStream32.reset();
         return this;
       }
+
+      @Override
+      public HashStream32 copy() {
+        return hashStream32.copy();
+      }
     };
   }
 
@@ -113,6 +118,11 @@ abstract class AbstractHasher32Test extends AbstractHasherTest {
               @Override
               public HashStream32 reset() {
                 return this;
+              }
+
+              @Override
+              public HashStream32 copy() {
+                throw new UnsupportedOperationException();
               }
 
               @Override

--- a/src/test/java/com/dynatrace/hash4j/hashing/AbstractHasher32Test.java
+++ b/src/test/java/com/dynatrace/hash4j/hashing/AbstractHasher32Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Dynatrace LLC
+ * Copyright 2022-2024 Dynatrace LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/dynatrace/hash4j/hashing/AbstractHasher64Test.java
+++ b/src/test/java/com/dynatrace/hash4j/hashing/AbstractHasher64Test.java
@@ -67,6 +67,11 @@ abstract class AbstractHasher64Test extends AbstractHasherTest {
         hashStream64.reset();
         return this;
       }
+
+      @Override
+      public HashStream64 copy() {
+        return hashStream64.copy();
+      }
     };
   }
 
@@ -117,6 +122,11 @@ abstract class AbstractHasher64Test extends AbstractHasherTest {
               @Override
               public HashStream64 reset() {
                 return this;
+              }
+
+              @Override
+              public HashStream64 copy() {
+                throw new UnsupportedOperationException();
               }
 
               @Override

--- a/src/test/java/com/dynatrace/hash4j/hashing/AbstractHasher64Test.java
+++ b/src/test/java/com/dynatrace/hash4j/hashing/AbstractHasher64Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Dynatrace LLC
+ * Copyright 2022-2024 Dynatrace LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/dynatrace/hash4j/hashing/AbstractHasherTest.java
+++ b/src/test/java/com/dynatrace/hash4j/hashing/AbstractHasherTest.java
@@ -1097,6 +1097,11 @@ abstract class AbstractHasherTest {
           public HashStream64 reset() {
             return referenceHashStream.reset();
           }
+
+          @Override
+          public HashStream64 copy() {
+            return referenceHashStream.copy();
+          }
         };
       }
 
@@ -1315,6 +1320,28 @@ abstract class AbstractHasherTest {
         assertThat(hash2).isEqualTo(hash1);
         assertThat(hash3).isEqualTo(hash1);
       }
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("getHashers")
+  void testCopy(Hasher hasher) {
+    final int numIterations = 10;
+    final byte[] bytes = new byte[100];
+    final SplittableRandom random = new SplittableRandom();
+    random.nextBytes(bytes);
+
+    final HashStream checkPoint = hasher.hashStream()
+        .putBytes(bytes);
+
+    for (int i = 0; i < numIterations; i++) {
+      final int index = random.nextInt();
+      final HashStream expected = hasher.hashStream()
+          .putBytes(bytes)
+          .putInt(index);
+      final HashStream actual = checkPoint.copy()
+          .putInt(index);
+      assertHashStreamEquals(expected, actual);
     }
   }
 }

--- a/src/test/java/com/dynatrace/hash4j/hashing/AbstractHasherTest.java
+++ b/src/test/java/com/dynatrace/hash4j/hashing/AbstractHasherTest.java
@@ -1331,16 +1331,12 @@ abstract class AbstractHasherTest {
     final SplittableRandom random = new SplittableRandom();
     random.nextBytes(bytes);
 
-    final HashStream checkPoint = hasher.hashStream()
-        .putBytes(bytes);
+    final HashStream checkPoint = hasher.hashStream().putBytes(bytes);
 
     for (int i = 0; i < numIterations; i++) {
       final int index = random.nextInt();
-      final HashStream expected = hasher.hashStream()
-          .putBytes(bytes)
-          .putInt(index);
-      final HashStream actual = checkPoint.copy()
-          .putInt(index);
+      final HashStream expected = hasher.hashStream().putBytes(bytes).putInt(index);
+      final HashStream actual = checkPoint.copy().putInt(index);
       assertHashStreamEquals(expected, actual);
     }
   }

--- a/src/test/java/com/dynatrace/hash4j/hashing/TestHashStream.java
+++ b/src/test/java/com/dynatrace/hash4j/hashing/TestHashStream.java
@@ -39,6 +39,14 @@ class TestHashStream extends AbstractHashStream {
   }
 
   @Override
+  public HashStream copy() {
+    final TestHashStream hashStream = new TestHashStream();
+    hashStream.size = size;
+    System.arraycopy(data, 0, hashStream.data, 0, data.length);
+    return hashStream;
+  }
+
+  @Override
   public int getHashBitSize() {
     throw new UnsupportedOperationException();
   }


### PR DESCRIPTION
Hi!
I suggest adding a state copy method for `HashStream`. This will be useful, for example, in [Consisten Hashing](https://liuzhenglaichn.gitbook.io/system-design/advanced/consistent-hashing) when calculating the hash of virtual nodes.

Then it would be possible to replace the code like:
```java
    for (int i = 0; i < numberOfReplicas; i++) {
      long hash = hasher.hashStream()
          .put(value, funnel) // <-- calculate the hash of the object each time
          .putInt(i)
          .getAsLong();

      ring.put(hash, value);
    }
```
replace the following code:
```java
    HashStream64 hashStream = hasher.hashStream()
        .put(value, funnel); // <- calculating the hash of an object once

    for (int i = 0; i < numberOfReplicas; i++) {
      long hash = hashStream.copy()
          .putInt(i)
          .getAsLong();

      ring.put(hash, value);
    }
```
the profit depends on the complexity of the hash calculation (`.put(value, funnel)`) and the number of replicas (`numberOfReplicas`).