### PR TITLE
comparison with JHash

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,11 +27,6 @@ plugins {
 	id "org.revapi.revapi-gradle-plugin" version "1.8.0" // TODO incompatibility with gradle 9
 }
 
-repositories {
-	mavenCentral()
-	gradlePluginPortal()
-}
-
 dependencies {
 	testImplementation("org.junit.jupiter:junit-jupiter-api:5.13.4")
 	testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.13.4")
@@ -46,6 +41,7 @@ dependencies {
 	testImplementation("com.appmattus.crypto:cryptohash:1.0.2")
 	testImplementation("org.greenrobot:essentials:3.1.0")
 	testImplementation("com.sangupta:murmur:1.0.0")
+	testImplementation("com.github.gbessonov:jHash:main-SNAPSHOT")
 	errorprone("com.google.errorprone:error_prone_core:2.42.0")
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,9 @@
 rootProject.name = "hash4j"
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+        maven { url 'https://jitpack.io' }
+    }
+}

--- a/src/jmh/java/com/dynatrace/hash4j/hashing/Murmur3_128JHashPerformanceTest.java
+++ b/src/jmh/java/com/dynatrace/hash4j/hashing/Murmur3_128JHashPerformanceTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022-2025 Dynatrace LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dynatrace.hash4j.hashing;
+
+import io.github.gbessonov.jhash.HashFunction;
+import io.github.gbessonov.jhash.JHash;
+import org.openjdk.jmh.infra.Blackhole;
+
+public class Murmur3_128JHashPerformanceTest extends AbstractPerformanceTest {
+
+  @Override
+  protected void hashObject(TestObject testObject, Blackhole blackhole) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  protected void hashBytesDirect(byte[] b, Blackhole blackhole) {
+    blackhole.consume(io.github.gbessonov.jhash.JHash.murmur3_128(b));
+  }
+
+  @Override
+  protected void hashCharsDirect(String s, Blackhole blackhole) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  protected void hashBytesIndirect(byte[] b, Blackhole blackhole) {
+    HashFunction hashFunction = JHash.newMurmur3_128();
+    hashFunction.include(b);
+    blackhole.consume(hashFunction.hash());
+  }
+
+  @Override
+  protected void hashCharsIndirect(String s, Blackhole blackhole) {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/src/test/java21/com/dynatrace/hash4j/internal/CrossCheckTest.java
+++ b/src/test/java21/com/dynatrace/hash4j/internal/CrossCheckTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2022-2025 Dynatrace LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dynatrace.hash4j.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.dynatrace.hash4j.hashing.Hashing;
+import java.util.SplittableRandom;
+import org.junit.jupiter.api.Test;
+
+class CrossCheckTest {
+
+  private static final int MAX_LENGTH = 2000;
+  private static final int NUM_ITERATIONS = 5;
+
+  @Test
+  void testMurmur3_128JHashMurmur3() {
+    SplittableRandom random = new SplittableRandom(0x60679c14de1c0954L);
+    for (int len = 0; len < MAX_LENGTH; ++len) {
+      byte[] b = new byte[len];
+      for (int i = 0; i < NUM_ITERATIONS; ++i) {
+        int seed = random.nextInt();
+        random.nextBytes(b);
+
+        assertThat(io.github.gbessonov.jhash.JHash.murmur3_128(b).getValueBytesLittleEndian())
+            .isEqualTo(Hashing.murmur3_128().hashBytesTo128Bits(b).toByteArray());
+        assertThat(
+                io.github.gbessonov.jhash.JHash.newMurmur3_128()
+                    .include(b)
+                    .hash()
+                    .getValueBytesLittleEndian())
+            .isEqualTo(Hashing.murmur3_128().hashBytesTo128Bits(b).toByteArray());
+        if (seed >= 0) {
+          // not compatible with reference implementation for negative seeds
+          assertThat(
+                  io.github.gbessonov.jhash.JHash.murmur3_128(b, seed).getValueBytesLittleEndian())
+              .isEqualTo(Hashing.murmur3_128(seed).hashBytesTo128Bits(b).toByteArray());
+          assertThat(
+                  io.github.gbessonov.jhash.JHash.newMurmur3_128(seed)
+                      .include(b)
+                      .hash()
+                      .getValueBytesLittleEndian())
+              .isEqualTo(Hashing.murmur3_128(seed).hashBytesTo128Bits(b).toByteArray());
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
```
Benchmark                                                Mode  Cnt      Score      Error  Units
Murmur3_128JHashPerformanceTest.hashBytes000001Direct    avgt   20      3.269 ┬▒    0.074  us/op
Murmur3_128JHashPerformanceTest.hashBytes000001Indirect  avgt   20      3.262 ┬▒    0.050  us/op
Murmur3_128JHashPerformanceTest.hashBytes000004Direct    avgt   20      3.379 ┬▒    0.049  us/op
Murmur3_128JHashPerformanceTest.hashBytes000004Indirect  avgt   20      3.347 ┬▒    0.043  us/op
Murmur3_128JHashPerformanceTest.hashBytes000016Direct    avgt   20      3.733 ┬▒    0.110  us/op
Murmur3_128JHashPerformanceTest.hashBytes000016Indirect  avgt   20      4.007 ┬▒    0.060  us/op
Murmur3_128JHashPerformanceTest.hashBytes000064Direct    avgt   20      6.401 ┬▒    0.424  us/op
Murmur3_128JHashPerformanceTest.hashBytes000064Indirect  avgt   20      6.671 ┬▒    0.327  us/op
Murmur3_128JHashPerformanceTest.hashBytes000256Direct    avgt   20     14.560 ┬▒    0.556  us/op
Murmur3_128JHashPerformanceTest.hashBytes000256Indirect  avgt   20     14.672 ┬▒    0.669  us/op
Murmur3_128JHashPerformanceTest.hashBytes001024Direct    avgt   20     46.504 ┬▒    2.588  us/op
Murmur3_128JHashPerformanceTest.hashBytes001024Indirect  avgt   20     46.134 ┬▒    4.425  us/op
Murmur3_128JHashPerformanceTest.hashBytes004096Direct    avgt   20    170.443 ┬▒   13.563  us/op
Murmur3_128JHashPerformanceTest.hashBytes004096Indirect  avgt   20    163.865 ┬▒   10.207  us/op
Murmur3_128JHashPerformanceTest.hashBytes016384Direct    avgt   20    631.386 ┬▒   26.969  us/op
Murmur3_128JHashPerformanceTest.hashBytes016384Indirect  avgt   20    680.496 ┬▒   47.603  us/op
Murmur3_128JHashPerformanceTest.hashBytes065536Direct    avgt   20   2665.136 ┬▒  169.404  us/op
Murmur3_128JHashPerformanceTest.hashBytes065536Indirect  avgt   20   2852.762 ┬▒  152.202  us/op
Murmur3_128PerformanceTest.hashBytes000001Direct         avgt   20      1.158 ┬▒    0.114  us/op
Murmur3_128PerformanceTest.hashBytes000001Indirect       avgt   20      2.362 ┬▒    0.206  us/op
Murmur3_128PerformanceTest.hashBytes000001ViaAccess      avgt   20      1.350 ┬▒    0.129  us/op
Murmur3_128PerformanceTest.hashBytes000004Direct         avgt   20      1.632 ┬▒    0.057  us/op
Murmur3_128PerformanceTest.hashBytes000004Indirect       avgt   20      2.092 ┬▒    0.074  us/op
Murmur3_128PerformanceTest.hashBytes000004ViaAccess      avgt   20      1.523 ┬▒    0.048  us/op
Murmur3_128PerformanceTest.hashBytes000016Direct         avgt   20      1.764 ┬▒    0.076  us/op
Murmur3_128PerformanceTest.hashBytes000016Indirect       avgt   20      2.208 ┬▒    0.106  us/op
Murmur3_128PerformanceTest.hashBytes000016ViaAccess      avgt   20      2.513 ┬▒    0.094  us/op
Murmur3_128PerformanceTest.hashBytes000064Direct         avgt   20      2.360 ┬▒    0.174  us/op
Murmur3_128PerformanceTest.hashBytes000064Indirect       avgt   20      2.790 ┬▒    0.180  us/op
Murmur3_128PerformanceTest.hashBytes000064ViaAccess      avgt   20      2.947 ┬▒    0.191  us/op
Murmur3_128PerformanceTest.hashBytes000256Direct         avgt   20      4.277 ┬▒    0.201  us/op
Murmur3_128PerformanceTest.hashBytes000256Indirect       avgt   20      4.665 ┬▒    0.259  us/op
Murmur3_128PerformanceTest.hashBytes000256ViaAccess      avgt   20      4.851 ┬▒    0.353  us/op
Murmur3_128PerformanceTest.hashBytes001024Direct         avgt   20     13.982 ┬▒    0.295  us/op
Murmur3_128PerformanceTest.hashBytes001024Indirect       avgt   20     13.280 ┬▒    0.518  us/op
Murmur3_128PerformanceTest.hashBytes001024ViaAccess      avgt   20     14.961 ┬▒    0.547  us/op
Murmur3_128PerformanceTest.hashBytes004096Direct         avgt   20     46.525 ┬▒    0.919  us/op
Murmur3_128PerformanceTest.hashBytes004096Indirect       avgt   20     46.093 ┬▒    1.193  us/op
Murmur3_128PerformanceTest.hashBytes004096ViaAccess      avgt   20     48.944 ┬▒    1.921  us/op
Murmur3_128PerformanceTest.hashBytes016384Direct         avgt   20    178.512 ┬▒    5.936  us/op
Murmur3_128PerformanceTest.hashBytes016384Indirect       avgt   20    180.274 ┬▒    5.912  us/op
Murmur3_128PerformanceTest.hashBytes016384ViaAccess      avgt   20    188.976 ┬▒    6.773  us/op
Murmur3_128PerformanceTest.hashBytes065536Direct         avgt   20    709.658 ┬▒   19.277  us/op
Murmur3_128PerformanceTest.hashBytes065536Indirect       avgt   20    705.710 ┬▒   26.577  us/op
Murmur3_128PerformanceTest.hashBytes065536ViaAccess      avgt   20    733.762 ┬▒   24.633  us/op
```