### PR TITLE
fix deduplicateTokens for ranges not starting at the beginning

### DIFF
--- a/src/main/java/com/dynatrace/hash4j/distinctcount/DistinctCountUtil.java
+++ b/src/main/java/com/dynatrace/hash4j/distinctcount/DistinctCountUtil.java
@@ -339,7 +339,7 @@ public final class DistinctCountUtil {
     if (toIndexExcl > fromIndexIncl) {
       int lastToken = tokens[fromIndexIncl];
       writeIndex += 1;
-      for (int readIndex = 1; readIndex < toIndexExcl; ++readIndex) {
+      for (int readIndex = fromIndexIncl + 1; readIndex < toIndexExcl; ++readIndex) {
         int token = tokens[readIndex];
         if (token != lastToken) {
           tokens[writeIndex] = token;

--- a/src/test/java/com/dynatrace/hash4j/distinctcount/DistinctCountUtilTest.java
+++ b/src/test/java/com/dynatrace/hash4j/distinctcount/DistinctCountUtilTest.java
@@ -310,5 +310,18 @@ class DistinctCountUtilTest {
       assertThat(tokens[2]).isEqualTo(5);
       assertThat(tokens[3]).isEqualTo(6);
     }
+    {
+      int[] tokens = {1, 2, 5, 5, 6};
+      assertThat(DistinctCountUtil.deduplicateTokens(tokens, 2, 5)).isEqualTo(4);
+      assertThat(tokens[0]).isEqualTo(1);
+      assertThat(tokens[1]).isEqualTo(2);
+      assertThat(tokens[2]).isEqualTo(5);
+      assertThat(tokens[3]).isEqualTo(6);
+    }
+    {
+      int[] tokens = {0, 0, 1};
+      assertThat(DistinctCountUtil.deduplicateTokens(tokens, 2, 3)).isEqualTo(3);
+      assertThat(tokens[2]).isEqualTo(1);
+    }
   }
 }


### PR DESCRIPTION
`DistinctCountUtil.deduplicateTokens(int[] tokens, int fromIndexIncl, int toIndexExcl)` honours `fromIndexIncl` in the sort, in the write cursor and in the seed read, but the scan loop starts at a hardcoded `1`:

```java
Arrays.sort(tokens, fromIndexIncl, toIndexExcl);
int writeIndex = fromIndexIncl;
if (toIndexExcl > fromIndexIncl) {
  int lastToken = tokens[fromIndexIncl];
  writeIndex += 1;
  for (int readIndex = 1; readIndex < toIndexExcl; ++readIndex) {
```

for `fromIndexIncl >= 2` the read cursor starts before the requested range, so elements from outside it get pulled into the output, the write cursor overruns slots that have not been read yet, and the returned index can exceed `toIndexExcl`

`deduplicateTokens(new int[] {1, 2, 5, 5, 6}, 2, 5)` throws `ArrayIndexOutOfBoundsException`. with spare capacity in the array there is no exception at all, the method just returns a range that is neither sorted nor deduplicated, which contradicts the javadoc

`fromIndexIncl` of 0 and 1 happen to be safe: at 0 the literal equals `fromIndexIncl + 1`, and at 1 the extra iteration re-reads the seed element and skips it as a duplicate. those are exactly the two values the existing test covers, which is why this went unnoticed

the natural use of the offset - keep an already deduplicated prefix and dedup a freshly appended tail - is the case that breaks

## changes

start the scan at `fromIndexIncl + 1` and add two cases to `testDeduplicateTokens`, one with spare capacity and one minimal single-element range

both new cases throw `ArrayIndexOutOfBoundsException` before the change and pass after. the existing cases are unaffected either way