### PR TITLE
Fix deduplicateTokens for ranges not starting at the beginning

### DIFF
--- a/src/main/java/com/dynatrace/hash4j/distinctcount/DistinctCountUtil.java
+++ b/src/main/java/com/dynatrace/hash4j/distinctcount/DistinctCountUtil.java
@@ -339,7 +339,7 @@ public final class DistinctCountUtil {
     if (toIndexExcl > fromIndexIncl) {
       int lastToken = tokens[fromIndexIncl];
       writeIndex += 1;
-      for (int readIndex = 1; readIndex < toIndexExcl; ++readIndex) {
+      for (int readIndex = fromIndexIncl + 1; readIndex < toIndexExcl; ++readIndex) {
         int token = tokens[readIndex];
         if (token != lastToken) {
           tokens[writeIndex] = token;

--- a/src/test/java/com/dynatrace/hash4j/distinctcount/DistinctCountUtilTest.java
+++ b/src/test/java/com/dynatrace/hash4j/distinctcount/DistinctCountUtilTest.java
@@ -310,5 +310,18 @@ class DistinctCountUtilTest {
       assertThat(tokens[2]).isEqualTo(5);
       assertThat(tokens[3]).isEqualTo(6);
     }
+    {
+      int[] tokens = {1, 2, 5, 5, 6};
+      assertThat(DistinctCountUtil.deduplicateTokens(tokens, 2, 5)).isEqualTo(4);
+      assertThat(tokens[0]).isEqualTo(1);
+      assertThat(tokens[1]).isEqualTo(2);
+      assertThat(tokens[2]).isEqualTo(5);
+      assertThat(tokens[3]).isEqualTo(6);
+    }
+    {
+      int[] tokens = {0, 0, 1};
+      assertThat(DistinctCountUtil.deduplicateTokens(tokens, 2, 3)).isEqualTo(3);
+      assertThat(tokens[2]).isEqualTo(1);
+    }
   }
 }


### PR DESCRIPTION
The scan started at index 1 instead of fromIndexIncl + 1, so for fromIndexIncl >= 2 it read elements from outside the requested range and the write cursor overran slots that had not been read yet. Depending on the array size that either threw or returned an unsorted range with duplicates.

The three statements above the loop already honour fromIndexIncl.